### PR TITLE
Service container should check if configuration exists when using isset

### DIFF
--- a/src/Service/Config/ContainerTest.php
+++ b/src/Service/Config/ContainerTest.php
@@ -144,6 +144,30 @@ class ContainerTest
     /**
      *
      */
+    function test_has_shared()
+    {
+        $config = new Container;
+        
+        $config->container(['foo' => 'bar']);
+
+        $this->assertEquals(true, $config->has('foo'));
+    }
+
+    /**
+     *
+     */
+    function test_has_service_config()
+    {
+        $config = new Container;
+        
+        $config->configure('foo', 'bar');
+
+        $this->assertEquals(true, $config->has('foo'));
+    }
+
+    /**
+     *
+     */
     function test_key_array()
     {
         $config = new Container;


### PR DESCRIPTION
The coalescing operator [bug fix](https://bugs.php.net/bug.php?id=71359) for php 7 requires the service container to check the service configuration when a shared value does not exist. Otherwise it will not be retrieved, e.g Request\Config::path().