### PR TITLE
Rename Object To Immutable

### DIFF
--- a/src/Config/ConfigTest.php
+++ b/src/Config/ConfigTest.php
@@ -8,6 +8,7 @@ namespace Mvc5\Test\Config;
 use Mvc5\App;
 use Mvc5\Arg;
 use Mvc5\Config;
+use Mvc5\Immutable;
 use Mvc5\Plugin\Value;
 use Mvc5\Test\Test\TestCase;
 
@@ -146,9 +147,39 @@ class ConfigTest
     /**
      *
      */
+    function test_with_immutable()
+    {
+        $config = new Config(new Immutable(['baz' => 'bat']));
+
+        $new = $config->with('foo', 'bar');
+
+        $this->assertNotEquals($new, $config);
+        $this->assertEquals(null,    $config->get('foo'));
+        $this->assertEquals('bar',   $new->get('foo'));
+        $this->assertEquals('bat',   $new->get('baz'));
+    }
+
+    /**
+     *
+     */
     function test_without()
     {
         $config = new Config(['foo' => 'bar', 'baz' => 'bat']);
+
+        $new = $config->without('foo');
+
+        $this->assertNotEquals($new, $config);
+        $this->assertEquals('bar',   $config->get('foo'));
+        $this->assertEquals(null,    $new->get('foo'));
+        $this->assertEquals('bat',   $new->get('baz'));
+    }
+
+    /**
+     *
+     */
+    function test_without_immutable()
+    {
+        $config = new Config(new Immutable(['foo' => 'bar', 'baz' => 'bat']));
 
         $new = $config->without('foo');
 

--- a/src/Config/ImmutableTest.php
+++ b/src/Config/ImmutableTest.php
@@ -5,7 +5,7 @@
 
 namespace Mvc5\Test\Config;
 
-use Mvc5\Object;
+use Mvc5\Immutable;
 use Mvc5\Test\Test\TestCase;
 
 class ImmutableTest
@@ -16,7 +16,7 @@ class ImmutableTest
      */
     function test_offset_set()
     {
-        $config = new Object;
+        $config = new Immutable;
 
         $this->setExpectedException(\Exception::class, 'Invalid operation: object cannot be modified');
 
@@ -28,7 +28,7 @@ class ImmutableTest
      */
     function test_property_set()
     {
-        $config = new Object;
+        $config = new Immutable;
 
         $this->setExpectedException(\Exception::class, 'Invalid operation: object cannot be modified');
 

--- a/src/Cookie/Config/ContainerTest.php
+++ b/src/Cookie/Config/ContainerTest.php
@@ -5,7 +5,6 @@
 
 namespace Mvc5\Test\Cookie\Config;
 
-use Mvc5\Config;
 use Mvc5\Test\Test\TestCase;
 
 class ContainerTest

--- a/src/Cookie/Config/SenderTest.php
+++ b/src/Cookie/Config/SenderTest.php
@@ -5,7 +5,6 @@
 
 namespace Mvc5\Test\Cookie\Config;
 
-use Mvc5\Config;
 use Mvc5\Test\Test\TestCase;
 
 class SenderTest

--- a/src/Resolver/Resolver/FilterTest.php
+++ b/src/Resolver/Resolver/FilterTest.php
@@ -8,7 +8,6 @@ namespace Mvc5\Test\Resolver\Resolver;
 use Mvc5\App;
 use Mvc5\Arg;
 use Mvc5\Plugin\Args;
-use Mvc5\Plugin\Config;
 use Mvc5\Plugin\Filter;
 use Mvc5\Plugin\Plugin;
 use Mvc5\Test\Resolver\Resolver;

--- a/src/Resolver/Resolver/Gem/FactoryTest.php
+++ b/src/Resolver/Resolver/Gem/FactoryTest.php
@@ -5,7 +5,6 @@
 
 namespace Mvc5\Test\Resolver\Resolver\Gem;
 
-use Mvc5\Config;
 use Mvc5\Plugin\Factory;
 use Mvc5\Plugin\Plugin;
 use Mvc5\Test\Resolver\Resolver;

--- a/src/Resolver/Resolver/Model/CallObject.php
+++ b/src/Resolver/Resolver/Model/CallObject.php
@@ -18,6 +18,7 @@ class CallObject
     /**
      * @param $foo
      * @param $bar
+     * @return mixed
      */
     function __invoke($foo, $bar)
     {

--- a/src/Resolver/Resolver/Model/Filterable.php
+++ b/src/Resolver/Resolver/Model/Filterable.php
@@ -10,6 +10,7 @@ class Filterable
     /**
      * @param $foo
      * @param $bar
+     * @return mixed
      */
     function __invoke($foo, $bar)
     {

--- a/src/Resolver/Resolver/Model/Hydrate.php
+++ b/src/Resolver/Resolver/Model/Hydrate.php
@@ -37,8 +37,8 @@ class Hydrate
 
     /**
      * @param $foo
-     * @param self $object
-     * @return self
+     * @param Hydrate $object
+     * @return Hydrate
      */
     function initialize($foo, self $object)
     {
@@ -58,8 +58,8 @@ class Hydrate
 
     /**
      * @param $foo
-     * @param self $object
-     * @return self
+     * @param Hydrate $object
+     * @return Hydrate
      */
     function __invoke($foo, self $object)
     {

--- a/src/Resolver/Resolver/ProvideTest.php
+++ b/src/Resolver/Resolver/ProvideTest.php
@@ -5,7 +5,6 @@
 
 namespace Mvc5\Test\Resolver\Resolver;
 
-use Mvc5\Config;
 use Mvc5\Plugin\Plugin;
 use Mvc5\Plugin\Value;
 use Mvc5\Test\Resolver\Resolver;

--- a/src/Resolver/Resolver/StrictTest.php
+++ b/src/Resolver/Resolver/StrictTest.php
@@ -5,8 +5,6 @@
 
 namespace Mvc5\Test\Resolver\Resolver;
 
-use Mvc5\Config;
-use Mvc5\Event;
 use Mvc5\Test\Resolver\Resolver;
 use Mvc5\Test\Test\TestCase;
 

--- a/src/Route/Dispatch.php
+++ b/src/Route/Dispatch.php
@@ -5,14 +5,14 @@
 
 namespace Mvc5\Test\Route;
 
-use Mvc5\Route\Dispatch\Router;
+use Mvc5\Route\Dispatch\Router as _Router;
 
 class Dispatch
 {
     /**
      *
      */
-    use Router {
+    use _Router {
         definition      as public;
         dispatch        as public;
         match           as public;

--- a/src/Route/Dispatch/RouterTest.php
+++ b/src/Route/Dispatch/RouterTest.php
@@ -7,7 +7,6 @@ namespace Mvc5\Test\Route\Router;
 
 use Mvc5\Arg;
 use Mvc5\App;
-use Mvc5\Event;
 use Mvc5\Http\Error\NotFound;
 use Mvc5\Http\Error\MethodNotAllowed;
 use Mvc5\Request\Config as Mvc5Request;

--- a/src/Signal.php
+++ b/src/Signal.php
@@ -37,8 +37,8 @@ class Signal
     }
 
     /**
-     * @param ...$args
-     * @return mixed
+     * @param array ...$args
+     * @return array|null
      */
     static function variadicArgsTest(...$args)
     {

--- a/src/Web/RouteTest.php
+++ b/src/Web/RouteTest.php
@@ -9,7 +9,6 @@ use Mvc5\App;
 use Mvc5\Arg;
 use Mvc5\Http\Request\Config as Request;
 use Mvc5\Http\Response\Config as Response;
-use Mvc5\Route\Config;
 use Mvc5\Route\Generator;
 use Mvc5\Route\Match;
 use Mvc5\Route\Match\Path;


### PR DESCRIPTION
Because "object" is a reserved keyword in PHP 7, the Mvc5 Object class has been renamed to Immutable. Additionally, the configuration methods "with" and "without" now work correctly with Immutable objects, e.g (new Mvc5\Config(new Mvc5\Immutable))->with('foo', 'bar');